### PR TITLE
fix: Add tsconfig.json for Next.js TypeScript project

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler", // Or "node" if using older Node versions/strategies
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"] // Common alias, adjust if your project uses components/lib differently
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
- Creates a standard tsconfig.json file with common compiler options for a Next.js TypeScript application, including path aliases for '@/*'.

This is a critical file for TypeScript compilation and module resolution, and its absence was likely causing build failures on Vercel.