### PR TITLE
refactor: Standardize import paths using tsconfig aliases

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
-import '../globals.css'; // Corrected path to root app/globals.css
+import '@/app/globals.css'; // Using path alias
+import { ReactNode } from 'react'; // Ensuring ReactNode is imported if not already
 
 export const metadata = {
   title: 'BeatMM Pro',

--- a/app/[locale]/live/page.tsx
+++ b/app/[locale]/live/page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useParams } from 'next/navigation';
-import { useTranslation } from '../../../i18n/client'; // Adjusted path
+import { useTranslation } from '@/app/i18n/client'; // Using path alias
 import { Container } from 'react-bootstrap';
 
 export default function LivePage() {

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -5,9 +5,9 @@ import Link from 'next/link';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { Container, Form, Button, Alert } from 'react-bootstrap';
 import { motion } from 'framer-motion';
-import { useTranslation } from '../../../i18n/client';
+import { useTranslation } from '@/app/i18n/client'; // Using path alias
 import { PhoneIcon, LockClosedIcon } from '@heroicons/react/24/outline';
-import { createSupabaseBrowserClient } from '../../../lib/supabase/client';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'; // Using path alias
 
 const SUPER_ADMIN_PHONES = ['09787715620', '09424425049'];
 

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useParams } from 'next/navigation';
-import { useTranslation } from '../../i18n/client'; // Adjust path as necessary
+import { useTranslation } from '@/app/i18n/client'; // Using path alias
 import { Container } from 'react-bootstrap';
 // You might want a language switcher here too, or handle it globally in layout.
 // For simplicity, I'll omit it from these placeholder pages for now but it can be added.

--- a/app/[locale]/profile/page.tsx
+++ b/app/[locale]/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useParams } from 'next/navigation';
-import { useTranslation } from '../../../i18n/client'; // Adjusted path
+import { useTranslation } from '@/app/i18n/client'; // Using path alias
 import { Container } from 'react-bootstrap';
 
 export default function ProfilePage() {

--- a/app/[locale]/register/page.tsx
+++ b/app/[locale]/register/page.tsx
@@ -5,9 +5,9 @@ import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
 import { Container, Form, Button, Alert } from 'react-bootstrap';
 import { motion } from 'framer-motion';
-import { useTranslation } from '../../../i18n/client';
+import { useTranslation } from '@/app/i18n/client'; // Using path alias
 import { UserIcon, PhoneIcon, LockClosedIcon } from '@heroicons/react/24/outline';
-import { createSupabaseBrowserClient } from '../../../lib/supabase/client'; // Import Supabase client
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'; // Using path alias
 
 // Animation Variants
 const containerVariants = {

--- a/app/[locale]/upload/page.tsx
+++ b/app/[locale]/upload/page.tsx
@@ -5,8 +5,8 @@ import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
 import { Container, Form, Button, Image, Alert } from 'react-bootstrap';
 import { motion } from 'framer-motion';
-import { useTranslation } from '../../../i18n/client';
-import { createSupabaseBrowserClient } from '../../../lib/supabase/client'; // Import Supabase client
+import { useTranslation } from '@/app/i18n/client'; // Using path alias
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'; // Using path alias
 import {
   MusicalNoteIcon,
   UserCircleIcon,

--- a/app/i18n/client.ts
+++ b/app/i18n/client.ts
@@ -4,7 +4,7 @@ import i18next from 'i18next';
 import { initReactI18next, useTranslation as useTranslationOrg } from 'react-i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 // import LanguageDetector from 'i18next-browser-languagedetector'; // Optional
-import { getOptions, languages } from './settings';
+import { getOptions, languages } from '@/app/i18n/settings'; // Using path alias
 import { useParams } from 'next/navigation'; // To get locale from URL
 
 const runsOnServerSide = typeof window === 'undefined';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".", // Added for robust path alias resolution
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
- Updates tsconfig.json to explicitly set compilerOptions.baseUrl = ".".
- Refactors import statements in all page components (within app/[locale]/**/page.tsx), the root locale layout (app/[locale]/layout.tsx), and i18n client setup (app/i18n/client.ts) to use the '@/*' path alias (e.g., '@/app/...', '@/lib/...').

This change aims to improve module resolution robustness, particularly for build environments like Vercel, and to address persistent 'Module not found' errors related to relative path interpretations.