### PR TITLE
fix: Correct Framer Motion ease property type errors

### DIFF
--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -21,7 +21,7 @@ const containerVariants = {
       delayChildren: 0.2,
       staggerChildren: 0.15,
       duration: 0.3,
-      ease: "circOut",
+      ease: "circOut" as const, // Explicitly typed string literal
     },
   },
 };
@@ -33,7 +33,7 @@ const itemVariants = {
     opacity: 1,
     transition: {
       duration: 0.35,
-      ease: "easeOut",
+      ease: "easeOut" as const, // Explicitly typed string literal
     },
   },
 };

--- a/app/[locale]/register/page.tsx
+++ b/app/[locale]/register/page.tsx
@@ -19,7 +19,7 @@ const containerVariants = {
       delayChildren: 0.2,
       staggerChildren: 0.15,
       duration: 0.3,
-      ease: "circOut",
+      ease: "circOut" as const, // Explicitly typed string literal
     },
   },
 };
@@ -31,7 +31,7 @@ const itemVariants = {
     opacity: 1,
     transition: {
       duration: 0.35,
-      ease: "easeOut",
+      ease: "easeOut" as const, // Explicitly typed string literal
     },
   },
 };

--- a/app/[locale]/upload/page.tsx
+++ b/app/[locale]/upload/page.tsx
@@ -26,7 +26,7 @@ const containerVariants = {
       delayChildren: 0.2,
       staggerChildren: 0.15,
       duration: 0.3,
-      ease: "circOut",
+      ease: "circOut" as const, // Explicitly typed string literal
     },
   },
 };
@@ -38,7 +38,7 @@ const itemVariants = {
     opacity: 1,
     transition: {
       duration: 0.35,
-      ease: "easeOut",
+      ease: "easeOut" as const, // Explicitly typed string literal
     },
   },
 };


### PR DESCRIPTION
- Modifies app/[locale]/login/page.tsx, app/[locale]/register/page.tsx, and app/[locale]/upload/page.tsx.
- Applies `as const` assertion to the `ease` string literals (e.g., "circOut", "easeOut") within Framer Motion variant definitions (containerVariants and itemVariants).

This change ensures TypeScript infers these strings as their specific literal types, resolving the type error where 'string' was not assignable to the 'Easing' union type expected by Framer Motion's transition config. This should fix the Vercel build failure related to this type error.