### PR TITLE
fix: Add explicit root redirect to default locale

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,19 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   i18n: {
-    locales: ['zh', 'en', 'my'], // Ensure all your defined locales are here
-    defaultLocale: 'zh',       // Set your default locale
-    localeDetection: false,    // Prevents automatic locale detection for simpler routing
+    locales: ['zh', 'en', 'my'],
+    defaultLocale: 'zh',
+    localeDetection: false,
+  },
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/zh', // Redirect root to defaultLocale
+        permanent: false,   // Set to true if this is a permanent redirect
+        locale: false,      // This redirect is not locale-specific itself
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
- Modifies next.config.js to include an explicit redirect from '/' to '/zh' (the default locale).
- This is intended to resolve 404 errors on the root path in Vercel deployments by ensuring the default locale's homepage is served, supplementing the `localeDetection: false` setting.