### PR TITLE
fix: update tsconfig moduleResolution to node

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler", // Or "node" if using older Node versions/strategies
+    "moduleResolution": "node", // Changed from "bundler" for broader compatibility with Next.js path alias resolution
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Changed moduleResolution in tsconfig.json from 'bundler' to 'node' to potentially improve path alias resolution stability during Next.js build.

Other previously identified build issues (Framer Motion types, i18n import paths, Bootstrap CSS, next.config.js i18n) appear to be addressed in the current version of the main branch based on file reads.